### PR TITLE
fix: update post:new script to work with inquirer v12+

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "lint": "biome lint",
     "lint:fix": "biome lint --write --unsafe",
     "format": "biome format --write",
-    "post:new": "node ./scripts/compose.js"
+    "post:new": "node ./scripts/compose.mjs"
   },
   "dependencies": {
     "@fontsource/inter": "5.2.6",

--- a/scripts/compose.mjs
+++ b/scripts/compose.mjs
@@ -1,7 +1,7 @@
-const fs = require("node:fs");
-const path = require("node:path");
-const inquirer = require("inquirer");
-const dedent = require("dedent");
+import fs from "node:fs";
+import path from "node:path";
+import inquirer from "inquirer";
+import dedent from "dedent";
 
 const root = process.cwd();
 
@@ -30,7 +30,9 @@ const genFrontMatter = (answers) => {
     `0${d.getDate()}`.slice(-2),
   ].join("-");
   const tagArray = answers.tags.split(",");
-  tagArray.forEach((tag, index) => tagArray[index] === tag.trim());
+  tagArray.forEach((tag, index) => {
+    tagArray[index] = tag.trim();
+  });
   const tags = `'${tagArray.join("','")}'`;
   const authorArray =
     answers.authors.length > 0 ? `'${answers.authors.join("','")}'` : "";
@@ -56,6 +58,17 @@ const genFrontMatter = (answers) => {
 
 inquirer
   .prompt([
+    {
+      name: "title",
+      message: "Enter post title:",
+      type: "input",
+      validate: (input) => {
+        if (input.trim().length === 0) {
+          return "Please enter a title for the post";
+        }
+        return true;
+      },
+    },
     {
       name: "extension",
       message: "Choose post extension:",
@@ -111,5 +124,6 @@ inquirer
       console.log("Prompt couldn't be rendered in the current environment");
     } else {
       console.log("Something went wrong, sorry!");
+      console.error(error);
     }
   });


### PR DESCRIPTION
Fixes the broken `pnpm post:new` command by:

- Converting compose.js to compose.mjs for ES module compatibility with inquirer v12+
- Adding missing title prompt with validation
- Fixing tag trimming logic that wasn't working
- Updating package.json script reference to new file

Fixes #26

Generated with [Claude Code](https://claude.ai/code)